### PR TITLE
Product Id added to Order Response 

### DIFF
--- a/src/modules/orders/interfaces/order-response-mapper.ts
+++ b/src/modules/orders/interfaces/order-response-mapper.ts
@@ -10,7 +10,8 @@ export abstract class OrderResponseMapper implements IInterceptor {
         id: data.buyer.id,
         name: data.buyer.getFullName()
       },
-      items: data.items.map((item) => ({
+      products: data.items.map((item) => ({
+        id: item.product.id,
         name: item.product.name,
         images: item.product.images,
         price: item.unitPrice,

--- a/src/modules/orders/interfaces/order-response.interface.ts
+++ b/src/modules/orders/interfaces/order-response.interface.ts
@@ -2,13 +2,14 @@ import { OrderStatus } from "./order-status"
 
 export interface IOrderResponse {
   id: string
-  items: OrderItemResponse[]
+  products: OrderItemResponse[]
   status: OrderStatus
   buyer: IdName
   createdAt: string
 }
 
 export interface OrderItemResponse {
+  id: string
   name: string
   images: string[]
   price: number


### PR DESCRIPTION
- Resolves #9 
- Each order Item now has its product ID added.
- I changed the order items array key from `items` to `products` since it is an array of products purchased with the order
<img width="1348" height="836" alt="Screenshot 2025-07-27 152137" src="https://github.com/user-attachments/assets/52608b00-c278-46f6-9ac5-b53f800518c1" />

 